### PR TITLE
[REFACOTR] Login Page UI + font

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -5,7 +5,7 @@
 :root {
     /* Typography */
     --serif: 'Pharmount Personal Use Only', serif;
-    --sans: 'Arial', sans-serif;
+    --sans: 'Titillium Web', sans-serif;
 
     /* Colors */
     --tertiary: #334046;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Titillium_Web } from 'next/font/google';
 
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
@@ -15,14 +15,10 @@ import OrdersProvider from '@/providers/OrdersContext';
 import { Toaster } from 'sonner';
 import { ReservationProvider } from '@/providers/ReservationsContext';
 
-const geistSans = Geist({
-    variable: '--font-geist-sans',
+const titilliumWeb = Titillium_Web({
+    variable: '--font-titillium-web',
     subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-    variable: '--font-geist-mono',
-    subsets: ['latin'],
+    weight: ['400', '700'],
 });
 
 export const generateMetadata = async (): Promise<Metadata> => {
@@ -42,7 +38,7 @@ const RootLayout = async ({
     return (
         <html lang={lang}>
             <body
-                className={`${geistSans.variable} ${geistMono.variable} flex justify-center items-center min-h-screen antialiased bg-page-gradient`}
+                className={`${titilliumWeb.variable} flex justify-center items-center min-h-screen antialiased bg-page-gradient`}
             >
                 <div id="root" className="w-full max-w-[64rem] relative">
                     <QueryProvider>

--- a/frontend/components/pages/login/Login.tsx
+++ b/frontend/components/pages/login/Login.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -9,72 +10,113 @@ import Input from '@/components/shared/Input/Input';
 import Button from '@/components/shared/button/Button';
 
 import languagePacks from '@/helpers/constants/languagePacks';
-import { COMPANY_NAME } from '@/helpers/constants/constants';
 import { getLoginSchema, type LoginSchema } from '@/helpers/models/loginForm';
+import { User } from 'lucide-react';
 
 const Login = () => {
+    // TODO: REMOVE OR CHANGE ACCORIDNG TO BACKEND
+    // mock zeby ten pin wpisac - i guess w local storage bedziemy trzymac czy ktos sie juz logowal w obrebie dzisiejszej dniowki
+
+    const [isUserAssignedToThisDevice, setIsUserAssignedToThisDevice] =
+        useState(true);
     const { language } = useLanguage();
-    const loginSchema = getLoginSchema(language);
+    const loginSchema = getLoginSchema(language, isUserAssignedToThisDevice);
     const {
         loginPage: {
-            appName,
-            form: { login, password, submit },
+            heading: { defaultHeading, userHasBeenAssignedHeading },
+            form: { login, password, pin, submit, pinLoginFallbackCta },
         },
     } = languagePacks[language];
+    const [pinHelpText, switchToMainLoginText = ''] = pinLoginFallbackCta
+        .split('||')
+        .map((text) => text.trim());
 
     const {
         handleSubmit,
+        reset,
         register,
         formState: { errors },
     } = useForm<LoginSchema>({
         resolver: zodResolver(loginSchema),
     });
 
+    useEffect(() => {
+        reset({
+            login: '',
+            password: '',
+            pin: '',
+        });
+    }, [isUserAssignedToThisDevice, reset]);
+
     const handleFormSubmit = (data: LoginSchema) => {
         console.log(data);
     };
 
     return (
-        <div className="pt-[3.375rem] mx-auto w-max text-white">
-            <header className="flex flex-col items-center mb-[5.15625rem]">
-                <h1
-                    className={`mb-[1.0625rem] font-serif capitalize ${h1Size}`}
-                >
-                    {COMPANY_NAME}
+        <div className="mx-[218px] flex flex-col items-center m-auto p-12 bg-[#0F2027B2] rounded-[20px]">
+            <header className="flex flex-col items-center gap-4">
+                <div className="bg-[#284C5C80] aspect-square w-[179px] rounded-[75px] flex items-center justify-center shadow-[0px 4px 4px 0px #00000040]">
+                    <User size={120} color="white" />
+                </div>
+                <h1 className="text-3xl uppercase text-white font-bold">
+                    {isUserAssignedToThisDevice
+                        ? userHasBeenAssignedHeading
+                        : defaultHeading}
                 </h1>
-                <h2 className="uppercase text-xl/9 font-bold">{appName}</h2>
-                <div className="mx-[-3.5px] h-[3px] w-full bg-white"></div>
             </header>
-
             <main>
                 <form
                     onSubmit={handleSubmit(handleFormSubmit)}
-                    className="flex flex-col gap-[1.0625rem]"
+                    className="flex flex-col items-center gap-3 mt-8"
                 >
-                    <Input
-                        type="text"
-                        id="login"
-                        label={login}
-                        {...register('login')}
-                        errors={errors.login}
-                        labelClassName={labelClasses}
-                        inputClassName={inputClasses}
-                    />
-                    <Input
-                        type="password"
-                        id="password"
-                        label={password}
-                        {...register('password')}
-                        errors={errors.password}
-                        labelClassName={labelClasses}
-                        inputClassName={inputClasses}
-                    />
-
-                    <Button
-                        className="mt-[2.1875rem] self-center uppercase font-bold"
-                        size="xl"
-                        variant="outline"
-                    >
+                    {isUserAssignedToThisDevice ? (
+                        <>
+                            <Input
+                                type="password"
+                                id="pin"
+                                label={pin}
+                                {...register('pin')}
+                                errors={errors.pin}
+                                labelClassName={labelClasses}
+                                inputClassName={inputClasses}
+                            />
+                            <p className="text-center text-white text-sm max-w-[420px]">
+                                {pinHelpText}{' '}
+                                <button
+                                    type="button"
+                                    className="underline underline-offset-4 font-bold"
+                                    onClick={() =>
+                                        // TODO: tu tez trzeba bd dorobic logike usuneicia z localstorage (prawdopodobnie) info o zalogowanym uzytkowniku
+                                        setIsUserAssignedToThisDevice(false)
+                                    }
+                                >
+                                    {switchToMainLoginText}
+                                </button>
+                            </p>
+                        </>
+                    ) : (
+                        <>
+                            <Input
+                                type="text"
+                                id="login"
+                                label={login}
+                                {...register('login')}
+                                errors={errors.login}
+                                labelClassName={labelClasses}
+                                inputClassName={inputClasses}
+                            />
+                            <Input
+                                type="password"
+                                id="password"
+                                label={password}
+                                {...register('password')}
+                                errors={errors.password}
+                                labelClassName={labelClasses}
+                                inputClassName={inputClasses}
+                            />
+                        </>
+                    )}
+                    <Button className="mt-8 uppercase font-bold">
                         {submit}
                     </Button>
                 </form>
@@ -83,7 +125,6 @@ const Login = () => {
     );
 };
 
-const h1Size = 'text-[12.5rem]/[12.5rem]';
 const inputClasses =
     'w-full text-xl/7 text-white text-center font-bold bg-opacity-30';
 const labelClasses = 'text-xl/9 text-center text-white uppercase';

--- a/frontend/helpers/constants/constants.ts
+++ b/frontend/helpers/constants/constants.ts
@@ -10,7 +10,7 @@ import daySummarySvg from '@/public/images/svg/end-of-day.svg';
 import settingsSvg from '@/public/images/svg/settings.svg';
 import homeSvg from '@/public/images/svg/home.svg';
 
-export const COMPANY_NAME = 'piccolo';
+export const COMPANY_NAME = 'Piccolo';
 export const RESTAURANT_OPENING_HOUR = '14:00';
 export const RESTAURANT_CLOSING_HOUR = '24:00';
 export const MIN_ITEM_SELECT = 1;

--- a/frontend/helpers/constants/languagePacks.ts
+++ b/frontend/helpers/constants/languagePacks.ts
@@ -29,10 +29,14 @@ export interface languagePack {
         noTableChosen?: string;
     };
     loginPage: {
-        appName: string;
+        heading: {
+            defaultHeading: string;
+            userHasBeenAssignedHeading: string;
+        };
         form: loginPageFormFields & {
             submit: string;
-            errors: loginPageFormFields;
+            pinLoginFallbackCta: string;
+            errors: loginPageFormErrors;
         };
     };
     menuBar: {
@@ -382,6 +386,13 @@ interface OrderEntity {
 interface loginPageFormFields {
     login: string;
     password: string;
+    pin: string;
+}
+
+interface loginPageFormErrors {
+    login: string;
+    password: string;
+    pin: string;
 }
 
 interface createReservationPageFormFields {

--- a/frontend/helpers/constants/languagePacks/english.ts
+++ b/frontend/helpers/constants/languagePacks/english.ts
@@ -16,14 +16,21 @@ const enPack: languagePack = {
         noTableChosen: 'Please choose a table',
     },
     loginPage: {
-        appName: 'order application',
+        heading: {
+            defaultHeading: 'Login to system',
+            userHasBeenAssignedHeading: 'User login',
+        },
         form: {
             login: 'login',
             password: 'password',
+            pin: 'enter PIN',
             submit: 'enter',
+            pinLoginFallbackCta:
+                "Don't remember your PIN or wasn't it you logging in today? || Go to the main login page",
             errors: {
                 login: 'Please enter at least 3 characters',
                 password: 'Please enter at least 8 characters',
+                pin: 'Please enter at least 4 digits',
             },
         },
     },

--- a/frontend/helpers/constants/languagePacks/polish.ts
+++ b/frontend/helpers/constants/languagePacks/polish.ts
@@ -16,14 +16,21 @@ const plPack: languagePack = {
         noTableChosen: 'Proszę wybrać stolik',
     },
     loginPage: {
-        appName: 'aplikacja do zamówień',
+        heading: {
+            defaultHeading: 'Logowanie do systemu',
+            userHasBeenAssignedHeading: 'Logowanie',
+        },
         form: {
             login: 'login',
-            submit: 'wejdź',
+            submit: 'zaloguj się',
             password: 'hasło',
+            pin: 'wpisz PIN',
+            pinLoginFallbackCta:
+                'Nie pamiętasz PIN-u lub to nie Ty dzisiaj się logowałeś? || Przejdź do głównej strony logowania',
             errors: {
                 login: 'Login musi mieć co najmniej 3 znaki',
                 password: 'Hasło musi mieć co najmniej 8 znaków',
+                pin: 'PIN musi mieć co najmniej 4 cyfry',
             },
         },
     },

--- a/frontend/helpers/models/loginForm.ts
+++ b/frontend/helpers/models/loginForm.ts
@@ -1,19 +1,57 @@
 import { z } from 'zod';
 import languagePacks, { LanguageTypes } from '../constants/languagePacks';
 
-export const getLoginSchema = (lang: LanguageTypes) => {
+const MIN_LOGIN_LENGTH = 3;
+const MIN_PASSWORD_LENGTH = 8;
+const MIN_PIN_LENGTH = 4;
+
+export const getLoginSchema = (
+    lang: LanguageTypes,
+    isUserAssignedToThisDevice: boolean
+) => {
     const {
         loginPage: {
             form: {
-                errors: { login, password },
+                errors: { login, password, pin },
             },
         },
     } = languagePacks[lang];
 
-    return z.object({
-        login: z.string().min(3, login),
-        password: z.string().min(8, password),
-    });
+    return z
+        .object({
+            login: z.string().optional(),
+            password: z.string().optional(),
+            pin: z.string().optional(),
+        })
+        .superRefine((data, ctx) => {
+            if (isUserAssignedToThisDevice) {
+                if (!data.pin || data.pin.trim().length < MIN_PIN_LENGTH) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['pin'],
+                        message: pin,
+                    });
+                }
+
+                return;
+            }
+
+            if (!data.login || data.login.trim().length < MIN_LOGIN_LENGTH) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['login'],
+                    message: login,
+                });
+            }
+
+            if (!data.password || data.password.length < MIN_PASSWORD_LENGTH) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['password'],
+                    message: password,
+                });
+            }
+        });
 };
 
 export type LoginSchema = z.infer<ReturnType<typeof getLoginSchema>>;


### PR DESCRIPTION
Refactored login page UI according to latest figma design. Added a fallback when user forgot the PIN or another user is trying to access the device. Also, as of now left the login button, instead of checking every keystroke in the PIN sequence.

Also added the font used in figma designs

<img width="1025" height="762" alt="image" src="https://github.com/user-attachments/assets/18a61756-f355-4060-8c1f-4b8d3c6b236c" />
<img width="1022" height="763" alt="image" src="https://github.com/user-attachments/assets/7eadf39e-6586-4ed2-a533-d0a165fa193f" />
